### PR TITLE
Change django container from tp33/django:1.0 to tp33/django:1.2

### DIFF
--- a/Project0.md
+++ b/Project0.md
@@ -51,22 +51,22 @@ Play with Docker
 After Docker is installed, we can test it.
 - Pull down the Docker containers for Django:
 ```
-	tp@devel:~$ docker pull tp33/django:1.0
-	1.0: Pulling from tp33/django
+	tp@devel:~$ docker pull tp33/django:1.2
+	1.2: Pulling from tp33/django
 	[...]
 	f9d42c108fd8: Pull complete 
 	Digest: sha256:90ff75c9817102fe0f5f5e9ff823bd0ea5ad05df24a87bd6def6c18f194da8a
-	Status: Downloaded newer image for tp33/django:1.0
+	Status: Downloaded newer image for tp33/django:1.2
 ```
 Docker works in a simiar way to Github. When you type
 ```
-    docker pull tp33/django:1.0
+    docker pull tp33/django:1.2
 ```
-it pulls the specific container 'django' from user 'tp33' with tag '1.0' to your local machine. The container has Django version 1.7.10 installed.
+it pulls the specific container 'django' from user 'tp33' with tag '1.2' to your local machine. The container has Django version 1.7.10 installed.
 
 You can then initialize a container.
 ```
-	tp@devel:~$ docker run -it --name web tp33/django:1.0
+	tp@devel:~$ docker run -it --name web tp33/django:1.2
 	root@4b6cb96f80f3:/app# python
 	Python 3.4.3 (default, Aug  9 2015, 11:14:27) 
 	[GCC 4.9.2] on linux
@@ -88,7 +88,7 @@ This command is used to see the status of containers you created. If you follow 
 ```
 	zeizyy@zeizyy-thinkpad:~/cs4501_ta$ docker ps -a
 	CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS                          PORTS               NAMES
-	ad3b71d8998e        tp33/django:1.0     "/bin/bash"              6 hours ago         Exited (0) About a minute ago                       web
+	ad3b71d8998e        tp33/django:1.2     "/bin/bash"              6 hours ago         Exited (0) About a minute ago                       web
 ```
 
 ###docker run IMAGE


### PR DESCRIPTION
Project 0 asks us to download version 1.0 of the django container.
Project 1 asks us to download version 1.2 of the django container. 

Project 1 is more important?