### PR TITLE
Convert to integers to prevent string concatenation

### DIFF
--- a/Project7.md
+++ b/Project7.md
@@ -91,7 +91,7 @@ data = sc.textFile("/tmp/data/access.log", 2)     # each worker loads a piece of
 
 pairs = data.map(lambda line: line.split("\t"))   # tell each worker to split each line of it's partition
 pages = pairs.map(lambda pair: (pair[1], 1))      # re-layout the data to ignore the user id
-count = pages.reduceByKey(lambda x,y: x+y)        # shuffle the data so that each key is only on one worker
+count = pages.reduceByKey(lambda x,y: int(x)+int(y))        # shuffle the data so that each key is only on one worker
                                                   # and then reduce all the values by adding them together
 
 output = count.collect()                          # bring the data back to the master node so we can print it out


### PR DESCRIPTION
With the test file, I was getting `tom  44` instead of `tom  8`.

It treated the variables as strings instead of integers - this should fix that.